### PR TITLE
[network] home 조회 api, 메인 투두 생성 api, 서브 투두 생성 Api 연결

### DIFF
--- a/TODOMate/TODOMate.xcodeproj/project.pbxproj
+++ b/TODOMate/TODOMate.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		5155B5A22DDDF959001E59FE /* HTTPMethodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5155B5A12DDDF953001E59FE /* HTTPMethodType.swift */; };
 		5155B5A52DDDFB39001E59FE /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5155B5A42DDDFB35001E59FE /* NetworkError.swift */; };
 		5155B5A72DDDFC9D001E59FE /* NetworkLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5155B5A62DDDFC98001E59FE /* NetworkLogger.swift */; };
-		5155B5AB2DDDFD09001E59FE /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 5155B5AA2DDDFD09001E59FE /* Config.xcconfig */; };
 		5155B6212DDE0060001E59FE /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5155B6202DDE005C001E59FE /* AppConfig.swift */; };
 		5155B6262DDE0422001E59FE /* DetailTasksResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5155B6252DDE040D001E59FE /* DetailTasksResponse.swift */; };
 		5155B6282DDE06DA001E59FE /* DetailTasksService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5155B6272DDE06CF001E59FE /* DetailTasksService.swift */; };
@@ -50,6 +49,9 @@
 		E52CDF392DD4741A00E22E00 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52CDF382DD4741A00E22E00 /* UIImage+.swift */; };
 		E52CDF3C2DD4D52500E22E00 /* ToDoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52CDF3B2DD4D52500E22E00 /* ToDoView.swift */; };
 		E52CDF3E2DD4D76A00E22E00 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52CDF3D2DD4D76A00E22E00 /* UIViewController+.swift */; };
+		E5524F022DDE29B100C396F4 /* AddTaskService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5524F012DDE29B100C396F4 /* AddTaskService.swift */; };
+		E5524F042DDE2AC900C396F4 /* AddMainTaskDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5524F032DDE2AC900C396F4 /* AddMainTaskDTO.swift */; };
+		E5524F062DDE2DA500C396F4 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E5524F052DDE2DA500C396F4 /* Config.xcconfig */; };
 		E554C98D2DD125CD002CF37B /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E554C98C2DD125CD002CF37B /* TabBarViewController.swift */; };
 		E567AB6A2DD20CEA00FA92E2 /* CustomNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E567AB692DD20CEA00FA92E2 /* CustomNavigationBar.swift */; };
 		E567AB6D2DD20D0100FA92E2 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = E567AB6C2DD20D0100FA92E2 /* Then */; };
@@ -70,7 +72,6 @@
 		5155B5A12DDDF953001E59FE /* HTTPMethodType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethodType.swift; sourceTree = "<group>"; };
 		5155B5A42DDDFB35001E59FE /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		5155B5A62DDDFC98001E59FE /* NetworkLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLogger.swift; sourceTree = "<group>"; };
-		5155B5AA2DDDFD09001E59FE /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		5155B6202DDE005C001E59FE /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		5155B6252DDE040D001E59FE /* DetailTasksResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTasksResponse.swift; sourceTree = "<group>"; };
 		5155B6272DDE06CF001E59FE /* DetailTasksService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTasksService.swift; sourceTree = "<group>"; };
@@ -105,6 +106,9 @@
 		E52CDF382DD4741A00E22E00 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		E52CDF3B2DD4D52500E22E00 /* ToDoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoView.swift; sourceTree = "<group>"; };
 		E52CDF3D2DD4D76A00E22E00 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
+		E5524F012DDE29B100C396F4 /* AddTaskService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskService.swift; sourceTree = "<group>"; };
+		E5524F032DDE2AC900C396F4 /* AddMainTaskDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMainTaskDTO.swift; sourceTree = "<group>"; };
+		E5524F052DDE2DA500C396F4 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		E554C98C2DD125CD002CF37B /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
 		E567AB692DD20CEA00FA92E2 /* CustomNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationBar.swift; sourceTree = "<group>"; };
 		E567AB742DD2119000FA92E2 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -168,6 +172,7 @@
 			isa = PBXGroup;
 			children = (
 				5155B6252DDE040D001E59FE /* DetailTasksResponse.swift */,
+				E5524F032DDE2AC900C396F4 /* AddMainTaskDTO.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -176,6 +181,7 @@
 			isa = PBXGroup;
 			children = (
 				5155B6272DDE06CF001E59FE /* DetailTasksService.swift */,
+				E5524F012DDE29B100C396F4 /* AddTaskService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -305,7 +311,7 @@
 				E5191F1B2DCC9790006F43B6 /* AppDelegate.swift */,
 				E5191F1F2DCC9790006F43B6 /* LaunchScreen.storyboard */,
 				E5191F222DCC9790006F43B6 /* SceneDelegate.swift */,
-				5155B5AA2DDDFD09001E59FE /* Config.xcconfig */,
+				E5524F052DDE2DA500C396F4 /* Config.xcconfig */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -524,9 +530,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E5524F062DDE2DA500C396F4 /* Config.xcconfig in Resources */,
 				E5191F5F2DCE5F21006F43B6 /* .swiftlint.yml in Resources */,
 				E5191F282DCC9790006F43B6 /* Assets.xcassets in Resources */,
-				5155B5AB2DDDFD09001E59FE /* Config.xcconfig in Resources */,
 				E5191F2A2DCC9790006F43B6 /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -595,6 +601,7 @@
 				D54548EA2DD6E3A600DBBE53 /* CustomDatePicker.swift in Sources */,
 				E567AB6A2DD20CEA00FA92E2 /* CustomNavigationBar.swift in Sources */,
 				5155B59A2DDDF6D2001E59FE /* BaseResponse.swift in Sources */,
+				E5524F042DDE2AC900C396F4 /* AddMainTaskDTO.swift in Sources */,
 				E52CDF072DD3AAD600E22E00 /* HomeViewController_sooyoung.swift in Sources */,
 				5155B5A02DDDF8DF001E59FE /* EndPoint.swift in Sources */,
 				E554C98D2DD125CD002CF37B /* TabBarViewController.swift in Sources */,
@@ -603,6 +610,7 @@
 				E52CDF3C2DD4D52500E22E00 /* ToDoView.swift in Sources */,
 				E5EF8DA22DD5343F00CF5BB2 /* ToDoModel.swift in Sources */,
 				E5191F262DCC9790006F43B6 /* SceneDelegate.swift in Sources */,
+				E5524F022DDE29B100C396F4 /* AddTaskService.swift in Sources */,
 				E5191F272DCC9790006F43B6 /* HomeViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -623,7 +631,6 @@
 /* Begin XCBuildConfiguration section */
 		E5191F172DCC975E006F43B6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5155B5AA2DDDFD09001E59FE /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -653,7 +660,6 @@
 		};
 		E5191F182DCC975E006F43B6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5155B5AA2DDDFD09001E59FE /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -683,7 +689,7 @@
 		};
 		E5191F192DCC975E006F43B6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5155B5AA2DDDFD09001E59FE /* Config.xcconfig */;
+			baseConfigurationReference = E5524F052DDE2DA500C396F4 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -747,7 +753,7 @@
 		};
 		E5191F1A2DCC975E006F43B6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5155B5AA2DDDFD09001E59FE /* Config.xcconfig */;
+			baseConfigurationReference = E5524F052DDE2DA500C396F4 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/TODOMate/TODOMate.xcodeproj/project.pbxproj
+++ b/TODOMate/TODOMate.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		E5524F022DDE29B100C396F4 /* AddTaskService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5524F012DDE29B100C396F4 /* AddTaskService.swift */; };
 		E5524F042DDE2AC900C396F4 /* AddMainTaskDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5524F032DDE2AC900C396F4 /* AddMainTaskDTO.swift */; };
 		E5524F062DDE2DA500C396F4 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E5524F052DDE2DA500C396F4 /* Config.xcconfig */; };
+		E5524F082DDE372800C396F4 /* AddSubTaskDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5524F072DDE372800C396F4 /* AddSubTaskDTO.swift */; };
+		E5524F1D2DDE418900C396F4 /* HomeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5524F1C2DDE418900C396F4 /* HomeModel.swift */; };
 		E554C98D2DD125CD002CF37B /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E554C98C2DD125CD002CF37B /* TabBarViewController.swift */; };
 		E567AB6A2DD20CEA00FA92E2 /* CustomNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E567AB692DD20CEA00FA92E2 /* CustomNavigationBar.swift */; };
 		E567AB6D2DD20D0100FA92E2 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = E567AB6C2DD20D0100FA92E2 /* Then */; };
@@ -109,6 +111,8 @@
 		E5524F012DDE29B100C396F4 /* AddTaskService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskService.swift; sourceTree = "<group>"; };
 		E5524F032DDE2AC900C396F4 /* AddMainTaskDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMainTaskDTO.swift; sourceTree = "<group>"; };
 		E5524F052DDE2DA500C396F4 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		E5524F072DDE372800C396F4 /* AddSubTaskDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSubTaskDTO.swift; sourceTree = "<group>"; };
+		E5524F1C2DDE418900C396F4 /* HomeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModel.swift; sourceTree = "<group>"; };
 		E554C98C2DD125CD002CF37B /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
 		E567AB692DD20CEA00FA92E2 /* CustomNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationBar.swift; sourceTree = "<group>"; };
 		E567AB742DD2119000FA92E2 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -173,6 +177,7 @@
 			children = (
 				5155B6252DDE040D001E59FE /* DetailTasksResponse.swift */,
 				E5524F032DDE2AC900C396F4 /* AddMainTaskDTO.swift */,
+				E5524F072DDE372800C396F4 /* AddSubTaskDTO.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -380,6 +385,14 @@
 			path = ToDoView;
 			sourceTree = "<group>";
 		};
+		E5524F1B2DDE416900C396F4 /* HomeModel */ = {
+			isa = PBXGroup;
+			children = (
+				E5524F1C2DDE418900C396F4 /* HomeModel.swift */,
+			);
+			path = HomeModel;
+			sourceTree = "<group>";
+		};
 		E554C98B2DD125A9002CF37B /* TabBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -408,8 +421,9 @@
 		E567AB712DD2117200FA92E2 /* Home */ = {
 			isa = PBXGroup;
 			children = (
-				E52CDF012DD3AA6D00E22E00 /* Sooyoung */,
 				E52CDF002DD3AA6600E22E00 /* Nayeon */,
+				E52CDF012DD3AA6D00E22E00 /* Sooyoung */,
+				E5524F1B2DDE416900C396F4 /* HomeModel */,
 				E567AB722DD2117900FA92E2 /* HomeViewController */,
 				E567AB732DD2118700FA92E2 /* HomeView */,
 			);
@@ -568,6 +582,7 @@
 			files = (
 				512563D32DD5A686009D1791 /* CalendarDateFormatter.swift in Sources */,
 				E567AB752DD2119000FA92E2 /* HomeView.swift in Sources */,
+				E5524F082DDE372800C396F4 /* AddSubTaskDTO.swift in Sources */,
 				E5191F3F2DCC9A5E006F43B6 /* UIView+.swift in Sources */,
 				5155B6212DDE0060001E59FE /* AppConfig.swift in Sources */,
 				5155B5A22DDDF959001E59FE /* HTTPMethodType.swift in Sources */,
@@ -585,6 +600,7 @@
 				513A22BB2DD5222600F28836 /* WeekCollectionViewCell.swift in Sources */,
 				51580CA52DD517FC00B56E7B /* WeekBoxLabel.swift in Sources */,
 				51580CA62DD517FC00B56E7B /* CalendarView.swift in Sources */,
+				E5524F1D2DDE418900C396F4 /* HomeModel.swift in Sources */,
 				5155B6262DDE0422001E59FE /* DetailTasksResponse.swift in Sources */,
 				5155B59E2DDDF7E8001E59FE /* BaseService.swift in Sources */,
 				D54548ED2DD6E3D200DBBE53 /* Priority.swift in Sources */,

--- a/TODOMate/TODOMate/Features/Home/HomeModel/HomeModel.swift
+++ b/TODOMate/TODOMate/Features/Home/HomeModel/HomeModel.swift
@@ -1,0 +1,37 @@
+//
+//  HomeModel.swift
+//  TODOMate
+//
+//  Created by 성현주 on 5/22/25.
+//
+
+import Foundation
+
+struct ToDoModelMapper {
+    static func map(from responses: [DetailTasksResponse]) -> [ToDoModel] {
+        let grouped = Dictionary(grouping: responses) { $0.category }
+
+        let categoryMap = [
+            "CATEGORY1": 1,
+            "CATEGORY2": 2,
+            "CATEGORY3": 3
+        ]
+
+        return grouped.compactMap { (categoryKey, tasks) -> ToDoModel? in
+            guard let categoryID = categoryMap[categoryKey] else { return nil }
+
+            let mainTasks = tasks.map { task in
+                MainTask(
+                    id: task.mainTaskId,
+                    text: task.taskContent,
+                    isDone: task.completed,
+                    subtasks: task.subTasks?.map {
+                        SubTask(id: $0.subTaskId, text: $0.content, isDone: $0.completed)
+                    } ?? []
+                )
+            }
+
+            return ToDoModel(categoryID: categoryID, mainTasks: mainTasks)
+        }
+    }
+}

--- a/TODOMate/TODOMate/Features/Home/HomeViewController/HomeViewController.swift
+++ b/TODOMate/TODOMate/Features/Home/HomeViewController/HomeViewController.swift
@@ -17,7 +17,9 @@ final class HomeViewController: BaseUIViewController {
     // MARK: - Singletone
     
     private let detailTasksService: DetailTasksService = DetailTasksService()
-    
+
+    private let addTaskService: AddTaskService = AddTaskService()
+
     // MARK: - Life Cycle
 
     override func viewDidLoad() {
@@ -81,11 +83,11 @@ final class HomeViewController: BaseUIViewController {
             listView.onCommit = { id, text, type, parentID in
                 if type == .main {
                     print("[카테고리\(index + 1)] 투두 생성됨yo → ID: \(id), 내용: \(text), 넌 어떤 타입이니?: \(type)")
+                    self.addMainTask(text: text, categoryIndex: index + 1)
                 } else {
                     print("[카테고리\(index + 1)] 투두 생성됨yo → ID: \(id), 내용: \(text), 넌 어떤 타입이니?: \(type), 서브구나 너 메인 아이디는 뭐냐고요: \(String(describing: parentID))")
                 }
             }
-
         }
     }
 
@@ -225,7 +227,7 @@ final class HomeViewController: BaseUIViewController {
     
     // MARK: - Network
     
-    func getDetailTodoList() {
+    private func getDetailTodoList() {
         Task {
             do {
                 let date = getSelectedDate()
@@ -236,6 +238,26 @@ final class HomeViewController: BaseUIViewController {
             }
         }
     }
+
+    private func addMainTask(text: String, categoryIndex: Int) {
+        let selectedDate = getSelectedDate()
+        let request = AddMainTaskRequest(
+            taskContent: text,
+            category: "CATEGORY\(categoryIndex)",
+            taskDate: "\(selectedDate)T00:00:00Z"
+        )
+
+        Task {
+            do {
+                let response = try await addTaskService.addMainTask(request: request)
+                print("메인 태스크 생성 성공: \(response)")
+                getDetailTodoList()
+            } catch {
+                print("메인 태스크 생성 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+
 }
 
 extension HomeViewController: isSelectCalendarCellDelegate {

--- a/TODOMate/TODOMate/Global/Components/Priority/Priority.swift
+++ b/TODOMate/TODOMate/Global/Components/Priority/Priority.swift
@@ -137,7 +137,6 @@ final class Priority: BaseUIView {
         completeButton.setTitleColor(.black, for: .normal)
     }
 
-    
     private func optionIndex(_ option: PriorityOption) -> Int {
         return PriorityOption.allCases.firstIndex(of: option) ?? 0
     }

--- a/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoListView.swift
+++ b/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoListView.swift
@@ -97,15 +97,23 @@ final class TodoListView: BaseUIView {
 
                 let viewsToRemove = todoViews[startIndex..<endIndex]
                 viewsToRemove.forEach {
-                    self.stackView.removeArrangedSubview($0)
-                    $0.removeFromSuperview()
+                    if self.stackView.arrangedSubviews.contains($0) {
+                        self.stackView.removeArrangedSubview($0)
+                        $0.removeFromSuperview()
+                    }
                 }
                 todoViews.removeSubrange(startIndex..<endIndex)
             } else {
+                guard !view.hasCommitted else {
+                    print("이미 커밋된 뷰입니다: \(view.uuid)")
+                    return
+                }
                 self.onCommit?(view.id, view.text, view.taskType, view.parentMainTaskID)
+                view.hasCommitted = true
             }
         }
     }
+
 
     private func configureToggleHandler(for view: TodoView) {
         view.onToggle = { [weak self] id, isSelected in
@@ -140,6 +148,7 @@ extension TodoListView {
             mainView.id = main.id
             mainView.text = main.text
             mainView.isSelected = main.isDone
+            mainView.hasCommitted = true
             stackView.addArrangedSubview(mainView)
             todoViews.append(mainView)
 
@@ -148,9 +157,11 @@ extension TodoListView {
                 subView.id = sub.id
                 subView.text = sub.text
                 subView.isSelected = sub.isDone
+                subView.hasCommitted = true 
                 stackView.addArrangedSubview(subView)
                 todoViews.append(subView)
             }
         }
     }
+
 }

--- a/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoListView.swift
+++ b/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoListView.swift
@@ -22,10 +22,10 @@ final class TodoListView: BaseUIView {
     private weak var focusedView: TodoView?
 
     /// 투두 완료했을때 사용하는 콜백입니다
-    var onToggle: ((UUID, Bool) -> Void)?
+    var onToggle: ((Int, Bool) -> Void)?
 
     /// 투두 등록할때 사용하는 콜백입니다
-    var onCommit: ((UUID, String, TodoView.TaskType, UUID?) -> Void)?
+    var onCommit: ((Int, String, TodoView.TaskType, Int?) -> Void)?
 
     // MARK: - Lifecycle
 
@@ -49,11 +49,11 @@ final class TodoListView: BaseUIView {
         guard let focusedView = focusedView else { return }
         guard let currentIndex = todoViews.firstIndex(of: focusedView) else { return }
 
-        let parentID: UUID
+        let parentID: Int
         if focusedView.taskType == .main {
             parentID = focusedView.id
         } else {
-            parentID = todoViews[..<currentIndex].last(where: { $0.taskType == .main })?.id ?? UUID()
+            parentID = todoViews[..<currentIndex].last(where: { $0.taskType == .main })?.id ?? Int()
         }
 
         let newSubView = makeTodoView(type: .sub, parentID: parentID, shouldFocus: true)
@@ -63,7 +63,7 @@ final class TodoListView: BaseUIView {
 
     // MARK: - Private Methods
 
-    private func makeTodoView(type: TodoView.TaskType, parentID: UUID? = nil, shouldFocus: Bool = false) -> TodoView {
+    private func makeTodoView(type: TodoView.TaskType, parentID: Int? = nil, shouldFocus: Bool = false) -> TodoView {
         let view = TodoView(taskType: type, shouldFocus: shouldFocus)
         view.parentMainTaskID = parentID
 

--- a/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoListView.swift
+++ b/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoListView.swift
@@ -114,7 +114,6 @@ final class TodoListView: BaseUIView {
         }
     }
 
-
     private func configureToggleHandler(for view: TodoView) {
         view.onToggle = { [weak self] id, isSelected in
             guard let self else { return }

--- a/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoModel/ToDoModel.swift
+++ b/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoModel/ToDoModel.swift
@@ -24,4 +24,3 @@ struct SubTask: Decodable {
     let text: String
     let isDone: Bool
 }
-

--- a/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoModel/ToDoModel.swift
+++ b/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoModel/ToDoModel.swift
@@ -13,92 +13,15 @@ struct ToDoModel: Decodable {
 }
 
 struct MainTask: Decodable {
-    let id: UUID
+    let id: Int
     let text: String
     let isDone: Bool
     let subtasks: [SubTask]
 }
 
 struct SubTask: Decodable {
-    let id: UUID
+    let id: Int
     let text: String
     let isDone: Bool
 }
 
-extension ToDoModel {
-    static func mockData() -> [ToDoModel] {
-        return [
-            ToDoModel(
-                categoryID: 1,
-                mainTasks: [
-                    MainTask(
-                        id: UUID(),
-                        text: "iOS 개발 공부하기",
-                        isDone: false,
-                        subtasks: [
-                            SubTask(id: UUID(), text: "MVVM 아키텍처 이해", isDone: false),
-                            SubTask(id: UUID(), text: "Combine 공부", isDone: true),
-                            SubTask(id: UUID(), text: "프로젝트 리팩토링", isDone: false)
-                        ]
-                    ),
-                    MainTask(
-                        id: UUID(),
-                        text: "iOS 개발 공부하기",
-                        isDone: false,
-                        subtasks: [
-                            SubTask(id: UUID(), text: "MVVM 아키텍처 이해", isDone: false),
-                            SubTask(id: UUID(), text: "Combine 공부", isDone: true),
-                            SubTask(id: UUID(), text: "프로젝트 리팩토링", isDone: false)
-                        ]
-                    ),
-                    MainTask(
-                        id: UUID(),
-                        text: "iOS 개발 공부하기",
-                        isDone: false,
-                        subtasks: [
-                            SubTask(id: UUID(), text: "MVVM 아키텍처 이해", isDone: false),
-                            SubTask(id: UUID(), text: "Combine 공부", isDone: true),
-                            SubTask(id: UUID(), text: "프로젝트 리팩토링", isDone: false)
-                        ]
-                    )
-                ]
-            ),
-            ToDoModel(
-                categoryID: 2,
-                mainTasks: [
-                    MainTask(
-                        id: UUID(),
-                        text: "iOS 개발 공부하기",
-                        isDone: false,
-                        subtasks: [
-                            SubTask(id: UUID(), text: "MVVM 아키텍처 이해", isDone: false),
-                            SubTask(id: UUID(), text: "Combine 공부", isDone: true),
-                            SubTask(id: UUID(), text: "프로젝트 리팩토링", isDone: false)
-                        ]
-                    ),
-                    MainTask(
-                        id: UUID(),
-                        text: "iOS 개발 공부하기",
-                        isDone: false,
-                        subtasks: [
-                            SubTask(id: UUID(), text: "MVVM 아키텍처 이해", isDone: false),
-                            SubTask(id: UUID(), text: "Combine 공부", isDone: true),
-                            SubTask(id: UUID(), text: "프로젝트 리팩토링", isDone: false)
-                        ]
-                    )
-                ]
-            ),
-            ToDoModel(
-                categoryID: 3,
-                mainTasks: [
-                    MainTask(
-                        id: UUID(),
-                        text: "거북목 대탈출",
-                        isDone: false,
-                        subtasks: []
-                    )
-                ]
-            )
-        ]
-    }
-}

--- a/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoView/ToDoView.swift
+++ b/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoView/ToDoView.swift
@@ -22,6 +22,9 @@ final class TodoView: BaseUIView {
 
     public var id: Int  = Int()
 
+    let uuid: UUID = UUID()
+    var hasCommitted: Bool = false
+
     public var onToggle: ((Int, Bool) -> Void)?
     public var onFocus: (() -> Void)?
     public var unFocus: (() -> Void)?

--- a/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoView/ToDoView.swift
+++ b/TODOMate/TODOMate/Global/Components/ToDoListView/ToDoView/ToDoView.swift
@@ -20,10 +20,9 @@ final class TodoView: BaseUIView {
 
     // MARK: - Properties
 
-    ///추후 int값으로 들어오는 id로 바꿀 예정입니다.
-    public var id: UUID = UUID()
+    public var id: Int  = Int()
 
-    public var onToggle: ((UUID, Bool) -> Void)?
+    public var onToggle: ((Int, Bool) -> Void)?
     public var onFocus: (() -> Void)?
     public var unFocus: (() -> Void)?
 
@@ -44,7 +43,7 @@ final class TodoView: BaseUIView {
 
     public let taskType: TaskType
 
-    public var parentMainTaskID: UUID?
+    public var parentMainTaskID: Int?
 
     // MARK: - UI Components
 

--- a/TODOMate/TODOMate/Global/Extensions/UIViewController+.swift
+++ b/TODOMate/TODOMate/Global/Extensions/UIViewController+.swift
@@ -37,4 +37,3 @@ extension UIViewController: UIGestureRecognizerDelegate {
             return true
         }
 }
-

--- a/TODOMate/TODOMate/Network/EndPoint.swift
+++ b/TODOMate/TODOMate/Network/EndPoint.swift
@@ -10,7 +10,7 @@ import Foundation
 enum EndPoint {
     case detailMainTasks(String)
     case postMainTasks
-    case postSubTasks
+    case postSubTasks(Int)
     case patchMainTasks
     case patchSubTasks
     
@@ -41,6 +41,11 @@ enum EndPoint {
     }
     
     var headers: [String: String] {
-        defaultHeaders
+        switch self {
+        case .postSubTasks(let taskId):
+            return defaultHeaders.merging(["taskId": "\(taskId)"]) { _, new in new }
+        default:
+            return defaultHeaders
+        }
     }
 }

--- a/TODOMate/TODOMate/Network/HTTPMethodType.swift
+++ b/TODOMate/TODOMate/Network/HTTPMethodType.swift
@@ -24,4 +24,4 @@ enum HTTPMethodType {
     }
 }
 
-let defaultHeaders = ["Content-Type": "application/json", "userId": "4"]
+let defaultHeaders = ["Content-Type": "application/json", "userId": "1"]

--- a/TODOMate/TODOMate/Network/Model/AddMainTaskDTO.swift
+++ b/TODOMate/TODOMate/Network/Model/AddMainTaskDTO.swift
@@ -1,0 +1,23 @@
+//
+//  AddMainTaskDTO.swift
+//  TODOMate
+//
+//  Created by 성현주 on 5/22/25.
+//
+
+import Foundation
+
+struct AddMainTaskRequest: Codable {
+    let taskContent: String
+    let category: String
+    let taskDate: String  
+}
+
+struct AddMainTaskResponse: Codable {
+    let mainTaskId: Int
+    let taskContent: String
+    let importance: String
+    let category: String
+    let taskDate: String
+    let completed: Bool
+}

--- a/TODOMate/TODOMate/Network/Model/AddSubTaskDTO.swift
+++ b/TODOMate/TODOMate/Network/Model/AddSubTaskDTO.swift
@@ -1,0 +1,19 @@
+//
+//  AddSubTaskDTO.swift
+//  TODOMate
+//
+//  Created by 성현주 on 5/22/25.
+//
+
+import Foundation
+
+struct AddSubTaskRequest: Codable {
+    let content: String
+}
+
+struct AddSubTaskResponse: Codable {
+    let id: Int
+    let taskContent: String
+    let completed: Bool
+    let mainTaskId: Int
+}

--- a/TODOMate/TODOMate/Network/NetworkLogger.swift
+++ b/TODOMate/TODOMate/Network/NetworkLogger.swift
@@ -86,8 +86,7 @@ final class NetworkLogger {
         output += "\nStatus Code: \(status)"
 
         if let data = data,
-            let str = String(data: data, encoding: .utf8)
-        {
+            let str = String(data: data, encoding: .utf8){
             output += "\n\nBody:\n\(str)"
         }
 

--- a/TODOMate/TODOMate/Network/Service/AddTaskService.swift
+++ b/TODOMate/TODOMate/Network/Service/AddTaskService.swift
@@ -1,0 +1,24 @@
+//
+//  AddTaskService.swift
+//  TODOMate
+//
+//  Created by 성현주 on 5/22/25.
+//
+
+import Foundation
+
+final class AddTaskService {
+    let shared = BaseService.shared
+
+    func addMainTask(request: AddMainTaskRequest) async throws -> AddMainTaskResponse {
+        do {
+            let response: AddMainTaskResponse = try await shared.request(
+                endPoint: .postMainTasks,
+                body: request
+            )
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/TODOMate/TODOMate/Network/Service/AddTaskService.swift
+++ b/TODOMate/TODOMate/Network/Service/AddTaskService.swift
@@ -21,4 +21,11 @@ final class AddTaskService {
             throw error
         }
     }
+
+    func addSubTask(mainTaskId: Int, request: AddSubTaskRequest) async throws -> AddSubTaskResponse {
+        return try await shared.request(
+            endPoint: .postSubTasks(mainTaskId),
+            body: request
+        )
+    }
 }


### PR DESCRIPTION
## ✅ 작업 내용

-home 조회 api, 메인 투두 생성 api, 서브 투두 생성 Api 연결
- 한번 commit된 투두가 계속 api 호출되는 문제가 있어서 각 투두뷰에 uuid를 부여하고, 호출여부를 저장하는 프로퍼티를 위치시켜, 호출할때 이 플래그 값을 변경해서 중복 호출을 막아뒀습니다
- homemodel에는 기존에 투두리스트에서 투두뷰를 보여주기 위해 설정했던 todomodel에 매핑한 값을 위치시켜 재사용할수 있도록 했습니다 스터디에서 공부한 배열이랑, 고차함수 한번 써봤어요 ㅎㅎ
- 뷰를 항상 최신화 하기 위해서, 투두생성시마다 일일 투두 조회 api를 호출해 뷰를 최신화 해줬습니다

  
## 💡 새로 알게 된 내용
<!--새로 알게 된 내용-->

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷 -->
<!-- 사용 예시
|    페이지    |   캡쳐   |
| :-------------: | :----------: |
| 피그마 | <img src = " " width = "250"> |
| 피그마 | <video src = "" width = "250">

-->
## 💭 Issue

- closed 이슈 번호

## ☄️ 트러블슈팅 링크
