### PR TITLE
[Fix]/#34 decode error 해결

### DIFF
--- a/TODOMate/TODOMate/Features/Home/HomeViewController/HomeViewController.swift
+++ b/TODOMate/TODOMate/Features/Home/HomeViewController/HomeViewController.swift
@@ -77,7 +77,7 @@ final class HomeViewController: BaseUIViewController {
                 
                 Task {
                     do {
-                        let result = try await self.subTaskPatchService.patchSubTask(id: id, request: [request])
+                        let result = try await self.subTaskPatchService.patchSubTask(id: id, request: request)
                         print("서브태스크 상태 패치 완료", result)
                     } catch {
                         print("패치 에러: \(error)")

--- a/TODOMate/TODOMate/Network/BaseService.swift
+++ b/TODOMate/TODOMate/Network/BaseService.swift
@@ -68,7 +68,19 @@ final class BaseService {
         do {
             print("type\(Response.self)")
             let decoded = try JSONDecoder().decode(BaseResponse<Response>.self, from: data)
+            print("디코딩된 데이터는요: ", decoded)
             
+            if Response.self == VoidType.self {
+                let successCodes = ["s2000", "s2010", "s2040"]
+                guard successCodes.contains(decoded.code) else {
+                    throw NetworkError.serverErrorMessage(decoded.message)
+                }
+
+                return (VoidType() as? Response) ?? {
+                       fatalError("VoidType을 Response로 변환할 수 없습니다.")
+               }()
+            }
+
             guard let data = decoded.data else {
                 throw NetworkError.noData
             }

--- a/TODOMate/TODOMate/Network/Service/SubTaskPatchService.swift
+++ b/TODOMate/TODOMate/Network/Service/SubTaskPatchService.swift
@@ -10,7 +10,7 @@ struct VoidType: Decodable {}
 final class SubTaskPatchService {
     let shared = BaseService.shared
     
-    func patchSubTask(id: Int, request: [SubTaskPatchRequest]) async throws -> BaseResponse<VoidType> {
+    func patchSubTask(id: Int, request: SubTaskPatchRequest) async throws -> BaseResponse<VoidType> {
         do {
             let response: BaseResponse<VoidType> = try await shared.request(
                 endPoint: .patchSubTasks(id),

--- a/TODOMate/TODOMate/Network/Service/SubTaskPatchService.swift
+++ b/TODOMate/TODOMate/Network/Service/SubTaskPatchService.swift
@@ -10,9 +10,9 @@ struct VoidType: Decodable {}
 final class SubTaskPatchService {
     let shared = BaseService.shared
     
-    func patchSubTask(id: Int, request: SubTaskPatchRequest) async throws -> BaseResponse<VoidType> {
+    func patchSubTask(id: Int, request: SubTaskPatchRequest) async throws -> VoidType {
         do {
-            let response: BaseResponse<VoidType> = try await shared.request(
+            let response: VoidType = try await shared.request(
                 endPoint: .patchSubTasks(id),
                 body: request
             )


### PR DESCRIPTION
## ✅ 작업 내용

<img src= "https://github.com/user-attachments/assets/94949bbb-69bb-4def-9cd7-838343b4c023" width = "500"/>

출처:수용오빠 사진 훔쳐옴

태스크 완료 Api 호출 시 디코딩 에러 뜨는 것 해결했습니다
  
## 💡 새로 알게 된 내용
<!--새로 알게 된 내용-->
PATCH api 리스폰스에서는 서버에서 보내주는 응답 중 data가 nil이기 때문에 디코딩 에러가 난다고 생각했습니다.
그래서 일단 baseservice의 requestToResponse 함수에서 decoded data를 로그에 찍어보았습니다. 
```
BaseResponse<BaseResponse<VoidType>>(code: "s2040", message: "요청이 성공했습니다.", data: nil)
```
요렇게 나오더라구요.. 이상하다..베이스리스폰스가 2개네..?
그렇습니다..제가 서비스 파일에서 리턴을 base response로 정해줬기 때문에 두번이나 감싸졌던 것입니다.

그래서
### SubTaskPatchService

``` swift
struct VoidType: Decodable {}

final class SubTaskPatchService {
    let shared = BaseService.shared
    
    func patchSubTask(id: Int, request: SubTaskPatchRequest) async throws -> VoidType {
        do {
            let response: VoidType = try await shared.request(
                endPoint: .patchSubTasks(id),
                body: request
            )
            return response
        } catch {
            throw error
        }
    }
}
```
사실 그렇잖아요 다른 api에서 리턴을 data 리스폰스 모델로 해줬는데 왜 여기서는 베이스리스폰스로 리턴을 정해줬징..... 
void type을 리턴타입으로 수정해줬습니다. 

### BaseService
``` swift
do {
            print("type\(Response.self)")
            let decoded = try JSONDecoder().decode(BaseResponse<Response>.self, from: data)
            print("디코딩된 데이터는요: ", decoded)
            
            if Response.self == VoidType.self {
                let successCodes = ["s2000", "s2010", "s2040"]
                guard successCodes.contains(decoded.code) else {
                    throw NetworkError.serverErrorMessage(decoded.message)
                }

                return (VoidType() as? Response) ?? {
                       fatalError("VoidType을 Response로 변환할 수 없습니다.")
               }()
            }

            guard let data = decoded.data else {
                throw NetworkError.noData
            }
            
            let successCodes = ["s2000", "s2010", "s2040"]
            guard successCodes.contains(decoded.code) else {
                throw NetworkError.serverErrorMessage(decoded.message)
            }

           return data
        }
```
그리고 base service에서 void type인 경우만 미리 분기를 해줬습니다.  사실 맞는 방법인진 모르겠어요...

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷 -->
<!-- 사용 예시
|    페이지    |   캡쳐   |
| :-------------: | :----------: |
| 피그마 | <img src = " " width = "250"> |
| 피그마 | <video src = "" width = "250">

-->
<img width="705" alt="image" src="https://github.com/user-attachments/assets/7ab72ba0-4843-46ce-89c5-7f5c45356976" />

## 💭 Issue

- closed #34 

## ☄️ 트러블슈팅 링크
